### PR TITLE
v0.4.15-alpha1-cs1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased
+- Removed remaining "CasaOS" references from code and documentation
+- Updated README to reflect CassetteOS naming
+
 ## v0.4.15-alpha1-cs1.1.1
 This patch version updates the Go environment to 1.20 to ensure consistent behavior in CI and go-licenses tooling.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,2 @@
-# CasaOS-Common
-
-[![Go Reference](https://pkg.go.dev/badge/github.com/BeesNestInc/CassetteOS-Common.svg)](https://pkg.go.dev/github.com/BeesNestInc/CassetteOS-Common) [![Go Report Card](https://goreportcard.com/badge/github.com/BeesNestInc/CassetteOS-Common)](https://goreportcard.com/report/github.com/BeesNestInc/CassetteOS-Common) [![codecov](https://codecov.io/github/IceWhaleTech/CasaOS-Common/branch/main/graph/badge.svg?token=KDJ5KAFX2Q)](https://codecov.io/github/IceWhaleTech/CasaOS-Common)
-
-Common structs and functions for CasaOS
+# CassetteOS-Common
+Common structs and functions for CassetteOS

--- a/external/notify.go
+++ b/external/notify.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	CasaOSURLFilename = "casaos.url"
-	APICasaOSNotify   = "/v1/notify"
+	CassetteOSURLFilename = "cassetteos.url"
+	APICassetteOSNotify   = "/v1/notify"
 )
 
 type NotifyService interface {
@@ -31,7 +31,7 @@ func (n *notifyService) SendNotify(path string, message interface{}) error {
 		return err
 	}
 
-	url := strings.TrimSuffix(address, "/") + APICasaOSNotify + "/" + path
+	url := strings.TrimSuffix(address, "/") + APICassetteOSNotify + "/" + path
 
 	body, err := json.Marshal(message)
 	if err != nil {
@@ -59,6 +59,6 @@ func (n *notifyService) SendSystemStatusNotify(message map[string]interface{}) e
 
 func NewNotifyService(runtimePath string) NotifyService {
 	return &notifyService{
-		addressFile: filepath.Join(runtimePath, CasaOSURLFilename),
+		addressFile: filepath.Join(runtimePath, CassetteOSURLFilename),
 	}
 }

--- a/external/share.go
+++ b/external/share.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	APICasaOSShare = "/v1/samba/shares"
+	APICassetteOSShare = "/v1/samba/shares"
 )
 
 type ShareService interface {
@@ -28,7 +28,7 @@ func (n *shareService) DeleteShare(id string) error {
 		return err
 	}
 
-	url := strings.TrimSuffix(address, "/") + APICasaOSShare + "/" + id
+	url := strings.TrimSuffix(address, "/") + APICassetteOSShare + "/" + id
 	fmt.Println(url)
 
 	response, err := http2.Delete(url, []byte("{}"), 30*time.Second)
@@ -45,6 +45,6 @@ func (n *shareService) DeleteShare(id string) error {
 
 func NewShareService(runtimePath string) ShareService {
 	return &shareService{
-		addressFile: filepath.Join(runtimePath, CasaOSURLFilename),
+		addressFile: filepath.Join(runtimePath, CassetteOSURLFilename),
 	}
 }

--- a/pkg/mod_management/sdk_test.go
+++ b/pkg/mod_management/sdk_test.go
@@ -25,7 +25,7 @@ func TestInstallModule(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.Skip()
 	}
-	err := modmanagement.RequireModule("doconverter", "/var/run/casaos")
+	err := modmanagement.RequireModule("doconverter", "/var/run/cassetteos")
 	assert.NoError(t, err)
 }
 
@@ -33,6 +33,6 @@ func TestInstallNoExistModule(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.Skip()
 	}
-	err := modmanagement.RequireModule("abc", "/var/run/casaos")
+	err := modmanagement.RequireModule("abc", "/var/run/cassetteos")
 	assert.ErrorIs(t, err, modmanagement.ErrModuleNoInStore)
 }

--- a/utils/command/command_test.go
+++ b/utils/command/command_test.go
@@ -68,7 +68,7 @@ func TestCommand(t *testing.T) {
 
 	t.Run("TestExecuteScripts", func(t *testing.T) {
 		// make a temp directory
-		tmpDir, err := os.MkdirTemp("", "casaos-test-*")
+		tmpDir, err := os.MkdirTemp("", "cassetteos-test-*")
 		if err != nil {
 			t.Error(err)
 		}

--- a/utils/constants/paths.go
+++ b/utils/constants/paths.go
@@ -1,10 +1,10 @@
 package constants
 
 const (
-	DefaultConfigPath   = "/etc/casaos"
-	DefaultConstantPath = "/usr/share/casaos"
-	DefaultDataPath     = "/var/lib/casaos"
-	DefaultFilePath     = "/var/lib/casaos/files"
-	DefaultLogPath      = "/var/log/casaos"
-	DefaultRuntimePath  = "/var/run/casaos"
+	DefaultConfigPath   = "/etc/cassetteos"
+	DefaultConstantPath = "/usr/share/cassetteos"
+	DefaultDataPath     = "/var/lib/cassetteos"
+	DefaultFilePath     = "/var/lib/cassetteos/files"
+	DefaultLogPath      = "/var/log/cassetteos"
+	DefaultRuntimePath  = "/var/run/cassetteos"
 )

--- a/utils/jwt/jwt.go
+++ b/utils/jwt/jwt.go
@@ -52,7 +52,7 @@ func ParseToken(signedToken string, publicKeyFunc func() (*ecdsa.PublicKey, erro
 
 // get AccessToken
 func GetAccessToken(username string, privateKey *ecdsa.PrivateKey, id int) (string, error) {
-	return GenerateToken(username, privateKey, id, "casaos", 3*time.Hour)
+	return GenerateToken(username, privateKey, id, "cassetteos", 3*time.Hour)
 }
 
 func GetRefreshToken(username string, private *ecdsa.PrivateKey, id int) (string, error) {

--- a/utils/version/migration.go
+++ b/utils/version/migration.go
@@ -13,7 +13,7 @@ type GlobalMigrationStatus struct {
 }
 
 var (
-	GlobalMigrationStatusDirPath = "/var/lib/casaos/migration"
+	GlobalMigrationStatusDirPath = "/var/lib/cassetteos/migration"
 
 	ErrInvalidServiceName = errors.New("service name should not contain space or upper case letter")
 )

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -13,17 +13,17 @@ import (
 )
 
 const (
-	LegacyCasaOSServiceName = "casaos.service"
+	LegacyCassetteOSServiceName = "cassetteos.service"
 	configKeyUniqueToZero3x = "USBAutoMount"
 	configKeyDBPath         = "DBPath"
 )
 
 var (
 	// this value will be updated at init() to actual config file path.
-	LegacyCasaOSConfigFilePath = "/etc/casaos.conf"
+	LegacyCassetteOSConfigFilePath = "/etc/cassetteos.conf"
 
 	_configFile        *ini.File
-	_casaOSBinFilePath string
+	_cassetteOSBinFilePath string
 )
 
 var (
@@ -32,7 +32,7 @@ var (
 )
 
 func init() {
-	serviceFilePath := file.FindFirstFile("/etc/systemd", LegacyCasaOSServiceName)
+	serviceFilePath := file.FindFirstFile("/etc/systemd", LegacyCassetteOSServiceName)
 	if serviceFilePath == "" {
 		return
 	}
@@ -55,11 +55,11 @@ func init() {
 	execStart := key.Value()
 	texts := strings.Split(execStart, " ")
 
-	// locaste casaos binary.
-	_casaOSBinFilePath = texts[0]
+	// locaste cassetteos binary.
+	_cassetteOSBinFilePath = texts[0]
 
-	if _, err := os.Stat(_casaOSBinFilePath); os.IsNotExist(err) {
-		_casaOSBinFilePath, err = exec.LookPath("casaos")
+	if _, err := os.Stat(_cassetteOSBinFilePath); os.IsNotExist(err) {
+		_cassetteOSBinFilePath, err = exec.LookPath("cassetteos")
 
 		if err != nil {
 			return
@@ -70,17 +70,17 @@ func init() {
 	if len(texts) > 2 {
 		for i, text := range texts {
 			if text == "-c" {
-				LegacyCasaOSConfigFilePath = texts[i+1]
+				LegacyCassetteOSConfigFilePath = texts[i+1]
 				break
 			}
 		}
 	}
 
-	if _, err := os.Stat(LegacyCasaOSConfigFilePath); os.IsNotExist(err) {
+	if _, err := os.Stat(LegacyCassetteOSConfigFilePath); os.IsNotExist(err) {
 		return
 	}
 
-	_configFile, _ = ini.Load(LegacyCasaOSConfigFilePath)
+	_configFile, _ = ini.Load(LegacyCassetteOSConfigFilePath)
 }
 
 func DetectLegacyVersion() (int, int, int, error) {
@@ -114,7 +114,7 @@ func DetectLegacyVersion() (int, int, int, error) {
 }
 
 func DetectVersion() (int, int, int, error) {
-	cmd := exec.Command(_casaOSBinFilePath, "-v")
+	cmd := exec.Command(_cassetteOSBinFilePath, "-v")
 	versionBytes, err := cmd.Output()
 	if err != nil {
 		return -1, -1, -1, ErrVersionNotFound
@@ -128,9 +128,9 @@ func DetectVersion() (int, int, int, error) {
 	return major, minor, patch, nil
 }
 
-// Detect minor version of CasaOS. It returns 2 for "0.2.x" or 3 for "0.3.x"
+// Detect minor version of CassetteOS. It returns 2 for "0.2.x" or 3 for "0.3.x"
 //
-// (This is often useful when failing to get version from API because CasaOS is not running.)
+// (This is often useful when failing to get version from API because CassetteOS is not running.)
 func DetectMinorVersion() (int, error) {
 	if _configFile == nil {
 		return -1, ErrLegacyVersionNotFound


### PR DESCRIPTION
残っていたCasaOSの参照を修正

- コード内やREADMEなどに残っていた "CasaOS" 表記を "CassetteOS" に修正しました
- 動作には影響しませんが、今後のメンテナンス性と一貫性のための整理です

この修正は v0.4.15-alpha1-cs1.1.2 としてリリース予定です
